### PR TITLE
chore: migrate to global-specific schema

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "$schema": "https://docs.renovatebot.com/renovate-global-schema.json",
   "logLevelRemap": [
     { "matchMessage": "/^branch.isModified\\(\\) = /", "newLogLevel": "debug" }
   ],


### PR DESCRIPTION
As using the repo schema with global configuration is deprecated in Renovate 42.x, and will be removed shortly in Renovate 43.x.